### PR TITLE
Added simple visualization

### DIFF
--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,37 @@
+import re
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+file_path = 'out.txt'
+with open(file_path, 'r') as file:
+    file_contents = file.readlines()
+
+data = []
+for line in file_contents:
+    match = re.search(r'\|\s+(\d+\.\d+)\s+TFLOPS\s+@\s+(\d+)x(\d+)x(\d+)', line)
+    if match:
+        tflops = float(match.group(1))
+        m = int(match.group(2))
+        n = int(match.group(3))
+        k = int(match.group(4))
+        data.append([tflops, m, n, k])
+
+df = pd.DataFrame(data, columns=['TFLOPS', 'M', 'N', 'K'])
+
+heatmap_data = pd.pivot_table(df, values='TFLOPS', index='M', columns='N', aggfunc=np.mean)
+
+plt.figure(figsize=(12, 12))
+
+plt.imshow(heatmap_data, cmap='rainbow', aspect='auto', origin='lower')
+
+plt.colorbar(label='TFLOPS')
+plt.title('TFLOPS Heatmap (M vs N)')
+plt.xlabel('N (Dimension)')
+plt.ylabel('M (Dimension)')
+
+plt.show()
+
+top_10_flops = df.sort_values(by='TFLOPS', ascending=False).head(20)
+
+print(top_10_flops)


### PR DESCRIPTION
![2024-09-16-182222_902x862_scrot](https://github.com/user-attachments/assets/505647e5-7064-45c4-8c46-24d1a0b033eb)

From a casual look it looks like 
```
( kill -STOP -1; CUDA_VISIBLE_DEVICES="0" timeout 3600s python mamf-finder.py ; kill -CONT -1)
```
Might yield substantially different results... 

Either that, or the CUDA scheduler is interfering with the timing, or the timing isn't done properly... 